### PR TITLE
Fix error handling when calling C.newlocale

### DIFF
--- a/localeinfo_linux.go
+++ b/localeinfo_linux.go
@@ -26,7 +26,7 @@ func NewLocale(name string) (*linuxLocale, error) {
 	clLocale := C.CString(name)
 	defer C.free(unsafe.Pointer(clLocale))
 	l, err := C.newlocale(C.LC_ALL_MASK, clLocale, nil)
-	if err != nil {
+	if l == nil {
 		return nil, err
 	}
 	return &linuxLocale{


### PR DESCRIPTION
I was working on package go-localeinfo for Debian, but I could not make the
tests work at all.

```
=== RUN   TestDateFmt
    localeinfo_test.go:18: NewLocale: no such file or directory
--- FAIL: TestDateFmt (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5091ee]

goroutine 6 [running]:
testing.tRunner.func1.2({0x521aa0, 0x62fba0})
        /usr/lib/go-1.22/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /usr/lib/go-1.22/src/testing/testing.go:1634 +0x377
panic({0x521aa0?, 0x62fba0?})
        /usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
github.com/delthas/go-localeinfo.(*linuxLocale).DateFormat(0xc0000b04e0?)
        /home/gui/packages/debian/senpai/golang-github-delthas-go-localeinfo/localeinfo_linux.go:52 +0x2e
github.com/delthas/go-localeinfo.TestDateFmt(0xc0000b04e0)
        /home/gui/packages/debian/senpai/golang-github-delthas-go-localeinfo/localeinfo_test.go:20 +0x92
testing.tRunner(0xc0000b04e0, 0x54ef58)
        /usr/lib/go-1.22/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /usr/lib/go-1.22/src/testing/testing.go:1742 +0x390
FAIL    github.com/delthas/go-localeinfo        0.004s
FAIL
```

I could make the segfault go away with `LC_ALL=C` or `LC_ALL=`, but the tests
don't expect the values in the C locale. When setting `LC_ALL` to anything
else, the segfault reappeared.

After doing some investigation with `strace`, I figured what was going wrong.
The relevant `strace` output when running with `LC_ALL=en_US` is:

```
openat(AT_FDCWD, "/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/locale.alias", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_CTYPE", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=301624, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 301624, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da3e000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_NUMERIC", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=59, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 59, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763df3f000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_TIME", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=3292, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 3292, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763df3e000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_COLLATE", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=21267, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 21267, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da38000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_MONETARY", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=291, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 291, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763df3d000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_MESSAGES", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFDIR|0755, st_size=4096, ...}, AT_EMPTY_PATH) = 0
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_MESSAGES/SYS_LC_MESSAGES", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=62, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 62, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da37000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_PAPER", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=39, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 39, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da36000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_NAME", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=82, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 82, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da35000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_ADDRESS", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=172, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 172, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da34000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_TELEPHONE", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=64, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 64, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da33000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_MEASUREMENT", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=28, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 28, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da32000
close(3)                                = 0
openat(AT_FDCWD, "/usr/lib/locale/en_US/LC_IDENTIFICATION", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=374, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 374, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f763da31000
close(3)                                = 0
nanosleep({tv_sec=0, tv_nsec=1000000}, NULL) = 0
nanosleep({tv_sec=0, tv_nsec=1000000}, NULL) = 0
write(2, "panic: ", 7panic: )                  = 7
write(2, "no such file or directory", 25no such file or directory) = 25
```

We can see that two `openat` syscalls are failing, but we eventually find the
`en_US` locale location. I don't actually know what
`/usr/lib/locale/locale-archive` and `/usr/share/locale/locale.alias` are, but
I don't think they are relevant to the failures at all.

The main problem here is that `errno` is set to `ENOENT`, even though the
locale was successfully loaded. This is stated on `newlocale(3)`.

> On success, `newlocale()` returns a handle that can be used ... On error,
> `newlocale()` returns `(locale_t) 0`, and sets `errno` to indicate the error.

This can be verified with this simple C program:

```c
#include <errno.h>
#include <locale.h>
#include <stdio.h>
#include <stdlib.h>

int main(void) {
        locale_t locale = newlocale(LC_ALL_MASK, "", NULL);
        printf("locale is NULL: %d\n", locale == NULL);
        printf("errno: %d\n", errno);
        return 0;
}
```

```bash
$ LC_ALL= ./a.out
locale is null: 0
errno: 0
$ LC_ALL=en_US ./a.out
locale is null: 0
errno: 2
```

The `NewLocale` function checks the return values of `C.newlocale`:

```go
l, err := C.newlocale(C.LC_ALL_MASK, "", nil)
if err != nil {
    return nil, err
}
```

The second return value is the value of `errno` set by the call to the
C function. We already established that `errno` can be `ENOENT` even if the
locale is found, so this error handling is not correct. The error when calling
`C.newlocale` is actually indicated by the `locale_t` pointer being `NULL`.

CGO is tricky :^)
